### PR TITLE
Desacoplando  app e container do mapa

### DIFF
--- a/src/game/GameMap.js
+++ b/src/game/GameMap.js
@@ -1,20 +1,19 @@
-import { TilingSprite, Container, ColorMatrixFilter, Graphics } from 'pixi.js'
+import { TilingSprite, ColorMatrixFilter, Graphics } from 'pixi.js'
 import { Controllable } from './controls/Controllable.js'
 
 export class GameMap extends Controllable {
-  constructor (app, mapTexture) {
+  constructor (container, mapTexture, width, height) {
     super()
-    this.app = app
-    this.container = new Container()
+    this.container = container
 
     this.background = new Graphics()
-      .rect(0, 0, app.screen.width, app.screen.height)
+      .rect(0, 0, width, height)
       .fill('0x172038')
 
     this.tilingSprite = new TilingSprite({
       texture: mapTexture,
-      width: app.screen.width,
-      height: app.screen.height
+      width,
+      height
 
     })
 
@@ -22,7 +21,6 @@ export class GameMap extends Controllable {
 
     this.container.addChild(this.background)
     this.container.addChild(this.tilingSprite)
-    app.stage.addChild(this.container)
 
     // a simple color filter
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { Application, Text, TextStyle, Assets } from 'pixi.js'
+import { Application, Text, TextStyle, Assets, Container } from 'pixi.js'
 import { GameMap } from './game/GameMap.js'
 import { ArrowControls } from './game/ArrowControls.js'
 import { Direction } from './game/enums/Direction.js'
@@ -25,6 +25,16 @@ async function setup () {
 
 (async () => {
   await setup()
+
+  // Decoupling rendering from game objects
+  const playerContainer = new Container()
+  const mapContainer = new Container()
+  const uiContainer = new Container()
+
+  app.stage.addChild(mapContainer)
+  app.stage.addChild(playerContainer)
+  app.stage.addChild(uiContainer)
+
 
   // Loads a very basic map:
 
@@ -70,7 +80,7 @@ async function setup () {
 
   const mapRenderTexture = isometricMapTextureCreator.create()
 
-  const map = new GameMap(app, mapRenderTexture)
+  const map = new GameMap(mapContainer, mapRenderTexture, app.screen.width, app.screen.height)
 
   // Map controls for scroll
 


### PR DESCRIPTION
GameMap recebe a dependência de um container ao invés de criar um novo. 
Também removi a dependência direta do app.